### PR TITLE
BZ-36417: chore: update blaze native sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,6 +98,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.github.juspay:blaze-sdk-android:0.0.13-alpha'
+  implementation 'com.github.juspay:blaze-sdk-android:0.0.18-alpha'
 }
 

--- a/blaze-sdk-react-native.podspec
+++ b/blaze-sdk-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "BlazeSDK", '0.1.0'
+  s.dependency "BlazeSDK", '0.3.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - blaze-sdk-react-native (0.0.15):
-    - BlazeSDK (= 0.1.0)
+  - blaze-sdk-react-native (0.0.19):
+    - BlazeSDK (= 0.2.0)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -21,7 +21,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - BlazeSDK (0.1.0)
+  - BlazeSDK (0.2.0)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.75.3)
@@ -1725,8 +1725,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  blaze-sdk-react-native: b166ae3f4c8785bf36b089e1d11e6b15a425c6ad
-  BlazeSDK: 77f9c1a89ae63219a20db06ef8c446a5552866a5
+  blaze-sdk-react-native: e42b7ffc8c672d9af8cfa96c538f9b6b7d5947ae
+  BlazeSDK: eb13425e886d13bf4e2066c7fa3a6567941321e6
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 7b438dceb9f904bd85ca3c31d64cce32a035472b

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,6 +7,7 @@ import {
   StatusBar,
   type StyleProp,
   type ViewStyle,
+  BackHandler,
 } from 'react-native';
 import { Colors } from 'react-native/Libraries/NewAppScreen';
 import BlazeSDK from '@juspay/blaze-sdk-react-native';
@@ -116,6 +117,16 @@ function createProcessPayload() {
 export default function App() {
   const isDarkMode = useColorScheme() === 'dark';
 
+  BackHandler.addEventListener('hardwareBackPress', () => {
+    const handleBackPress = BlazeSDK.handleBackPress();
+    if (handleBackPress) {
+      // Skip this backpress event, Blaze SDK will handle the event
+      return false;
+    }
+
+    return true;
+  });
+
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
@@ -143,6 +154,10 @@ export default function App() {
     BlazeSDK.process(createSDKPayload(createProcessPayload()));
   };
 
+  const terminateSDK = () => {
+    BlazeSDK.terminate();
+  };
+
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar
@@ -157,6 +172,7 @@ export default function App() {
         <View style={containerViewStyle}>
           <Button title="Initiate" onPress={initiateSDK} />
           <Button title="Process" onPress={processSDK} />
+          <Button title="Terminate" onPress={terminateSDK} />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juspay/blaze-sdk-react-native",
-  "version": "0.0.16",
+  "version": "0.0.20",
   "description": "SDK for integrating Breeze 1CCO into your React Native Application",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
- upgrade android sdk to 0.0.18-alpha & ios sdk to 0.3.0
- updated example to using terminate