### PR TITLE
BZ-42528: chore: update blaze native sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -98,6 +98,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.github.juspay:blaze-sdk-android:0.0.18-alpha'
+  implementation 'com.github.juspay:blaze-sdk-android:0.0.19-alpha'
 }
 

--- a/blaze-sdk-react-native.podspec
+++ b/blaze-sdk-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "BlazeSDK", '0.3.0'
+  s.dependency "BlazeSDK", '0.4.0'
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - blaze-sdk-react-native (0.0.19):
-    - BlazeSDK (= 0.2.0)
+  - blaze-sdk-react-native (0.0.21):
+    - BlazeSDK (= 0.4.0)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -21,7 +21,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - BlazeSDK (0.2.0)
+  - BlazeSDK (0.4.0)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.75.3)
@@ -1725,72 +1725,72 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  blaze-sdk-react-native: e42b7ffc8c672d9af8cfa96c538f9b6b7d5947ae
-  BlazeSDK: eb13425e886d13bf4e2066c7fa3a6567941321e6
+  blaze-sdk-react-native: d26500eb089889771a91d6dc6d7a7f6508eaa527
+  BlazeSDK: 151d142d6cb621b14258242fccb99df3d4e10540
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 7b438dceb9f904bd85ca3c31d64cce32a035472b
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 8d2103d6c0176779aea4e25df6bb1410f9946680
-  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
+  RCT-Folly: 34124ae2e667a0e5f0ea378db071d27548124321
   RCTDeprecation: 4191f6e64b72d9743f6fe1a8a16e89e868f5e9e7
   RCTRequired: 9bb589570f2bb3abc6518761e3fd1ad9b7f7f06c
   RCTTypeSafety: 1c1a8741c86df0a0ac1a99cf3fb0e29eedbc2c88
   React: b6810a201ee11e69ae8bfd4eb4aaab86610600bf
   React-callinvoker: d6c7898b63e6a2d37bc308f17c05be0ba3630b10
-  React-Core: 2fc97900b68e7568233698c6113ca9d64ed8b520
-  React-CoreModules: 2d68c251bc4080028f2835fa47504e8f20669a21
-  React-cxxreact: 5f233f8ac7ea4772e49462e0ab2b0a15a4f80ab7
+  React-Core: 411ef2293ba0c9147e04ee89324bc1575b38a089
+  React-CoreModules: 30c44229d249317498dac4a984925c56e06f61c2
+  React-cxxreact: 1ba92740ea3ed5be86898dec22f6548aa843da16
   React-debug: fd0ed8ecd5f8a23c7daf5ceaca8aa722a4d083fd
-  React-defaultsnativemodule: 10f0f8bc38d8dc7d2273572cd85ed0b71298ecdd
-  React-domnativemodule: bfef3dda59e7030b498d0d78628f4adf414ab8e4
-  React-Fabric: 3d0f5e2735d2f77a897ee684edeff7bb0e061919
-  React-FabricComponents: 68032a85a3c25c9c8d6ce676d8af9a85e2370f24
-  React-FabricImage: f8ac2df576703097b5b2f8d972b162cdca855aa3
+  React-defaultsnativemodule: 33038152921d2f3fdef66ba1f8ef32e9ee68a834
+  React-domnativemodule: 6e79b766cda4b3a447aa59aaf04473d257b0c5bb
+  React-Fabric: da5caca65022dcbbb95d12cebcde7770fdd44ff0
+  React-FabricComponents: 19e0eb8be8d8f2afa1a921705a87d8818eba14cf
+  React-FabricImage: 50df9e6aace1781cf23e130171631d7674b4072c
   React-featureflags: cf78861db9318ae29982fa8953c92d31b276c9ac
-  React-featureflagsnativemodule: d04eb5c3f0ac33fe70b060d97e8649bfd69c5f1e
-  React-graphics: 7572851bca7242416b648c45d6af87d93d29281e
-  React-hermes: 95c27801c60615345ee6256eafa6d597ce983b8b
-  React-idlecallbacksnativemodule: f5f0b760ec2739b30e315e1afee3dd3a5a93c3b6
-  React-ImageManager: aedf54d34d4475c66f4c3da6b8359b95bee904e4
-  React-jserrorhandler: 0c8949672a00f2a502c767350e591e3ec3d82fb3
-  React-jsi: d77bb442a4b0849063f2bd22d3c1fa71918713b7
-  React-jsiexecutor: 3b9c6334b7b0f42d4c4aae950132766e63a7809f
-  React-jsinspector: e1bb5816869507527c30213cc1ed60eae9e3e9c4
-  React-jsitracing: 3935b092f85bb1e53b8cf8a00f572413648af46b
-  React-logger: 4072f39df335ca443932e0ccece41fbeb5ca8404
-  React-Mapbuffer: 714f2fae68edcabfc332b754e9fbaa8cfc68fdd4
-  React-microtasksnativemodule: 4943ad8f99be8ccf5a63329fa7d269816609df9e
+  React-featureflagsnativemodule: 3ff0c243e064a252293afb24aa0a6ee36b0149e4
+  React-graphics: 7ed2dc99f706228448b870882729a8303343b5a5
+  React-hermes: 167b427c2106b92ac47add9b35ca024d42453518
+  React-idlecallbacksnativemodule: 6b917d089d3beaa096c6c95bcb428c4577fe65de
+  React-ImageManager: 9970421c57b6458d3a4d6ce319c9067217c4882f
+  React-jserrorhandler: 6764a4b7abd617332fb0935c9ba63a6369207a15
+  React-jsi: 7713fae6d70c49a1b1b12d7e65ca62a50cd820d2
+  React-jsiexecutor: 67260e3eb3d1f3d3fd41ff15e89ce4027ae9c36a
+  React-jsinspector: a0f1febb0bcf5770ff135444a6afee7520ee42f7
+  React-jsitracing: bf77e00063522e4fd6d84fa129f0caaf360d275e
+  React-logger: 7e56c9eceafd7f45e98c16cb42ff3c9966c67119
+  React-Mapbuffer: e68dd904f0f3a84dd35989288ed3bcf5e37f9737
+  React-microtasksnativemodule: ca8806e64625be04b8f3d9f31f66508d02c42555
   React-nativeconfig: 4a9543185905fe41014c06776bf126083795aed9
-  React-NativeModulesApple: 0506da59fc40d2e1e6e12a233db5e81c46face27
+  React-NativeModulesApple: f6b6dc0998c945dd113858f1fc12e5e5f0da0990
   React-perflogger: 3bbb82f18e9ac29a1a6931568e99d6305ef4403b
-  React-performancetimeline: d15a723422ed500f47cb271f3175abbeb217f5ba
+  React-performancetimeline: 05c0372923c2f3a9e8a5ae954258f0436003bffb
   React-RCTActionSheet: cb2b38a53d03ec22f1159c89667b86c2c490d92d
-  React-RCTAnimation: 6836c87c7364f471e9077fda80b7349bc674be33
-  React-RCTAppDelegate: 2f11edfa7302451c792591f9a7838ca86cdcec34
-  React-RCTBlob: 516dbbd38397f5013394fdd1cc65408cc82e37a1
-  React-RCTFabric: b281a52c2b9726b0c64880e1535f2100013d5f7c
-  React-RCTImage: 1b2c2c1716db859ffff2d7a06a30b0ec5c677fc5
-  React-RCTLinking: 59c07577767e705b0ab95d11e5ad74c61bf2a022
-  React-RCTNetwork: f9a827e7d6bc428e0d99cd1fbe0427854354b8c1
-  React-RCTSettings: 614252fecc24840f61590c016aca1664a52cfb0f
-  React-RCTText: 424549f68867265aa25969f50e7b9bf8bd70ae55
-  React-RCTVibration: c8d156e6cce18f00b0310db7670fa997c7cda407
+  React-RCTAnimation: c8be4f58eabb487d6346247ee8e7bac434737ed7
+  React-RCTAppDelegate: d34bc2eeddc4d3f2a23275bf45e915d0d5df5284
+  React-RCTBlob: 7a64271f64a60390a2e73edecaca2735be8044ff
+  React-RCTFabric: dc41b0a646666b7e8db159c26eeda20af8b6328f
+  React-RCTImage: 4fb571875362a78ccc01aded76b94a71ae466b8b
+  React-RCTLinking: e825182eaf7f4047f6bb11bb6cd2ae5858008e66
+  React-RCTNetwork: 0e07b83395b6ff5016f7cea4ac99426a893a1438
+  React-RCTSettings: bd68792732f116994e992cf48e5bb70c4eb3910e
+  React-RCTText: c3cfce62ddb887cdd86403a6130a58a1f8fed9f3
+  React-RCTVibration: 32a10228b7affa8de6401dba6f0d73b5a8433342
   React-rendererconsistency: 993f54bb0df644df2922cd87ea55238d510d992b
-  React-rendererdebug: 7a8cbb632b68d666ad0fc01b3f9dc1a1bcc9a9f9
+  React-rendererdebug: 9cd1f3e6d12c1d9b99fce6ceb373495b29b3d9ee
   React-rncore: 1df26fe0ae861c599f9f2896f45e8834ef4b85f9
-  React-RuntimeApple: b5b14b09e3be4058f9fe7ab4925e1ee343f03310
-  React-RuntimeCore: 2073fb33da2aec6ce6c1c9d3d53898ed1f1d806d
+  React-RuntimeApple: 5fb9053ae46ec14407f24547afd903ec8f0c0b9a
+  React-RuntimeCore: f6af8417106c1ce5b494edd99e86b0d0069ad6c3
   React-runtimeexecutor: 9a668b94ad5d93755443311715bd57680330286a
-  React-RuntimeHermes: b37c62718d6920ac2958a0052bdc1b01aca842b8
-  React-runtimescheduler: e25750a18cbb7469e0513f1ace834d14e8c1a202
-  React-utils: f2afa6acd905ca2ce7bb8ffb4a22f7f8a12534e8
-  ReactCodegen: ff95a93d5ab5d9b2551571886271478eaa168565
-  ReactCommon: 289214026502e6a93484f4a46bcc0efa4f3f2864
+  React-RuntimeHermes: 6c6053fb5aca5558b071cfbce2868ca50a3b8fc7
+  React-runtimescheduler: 5d1a32712d441c38e6d5815069e1810d38ed26f7
+  React-utils: 3c815e7d3abb801930a3df2db870c92855429fea
+  ReactCodegen: 3d11bcf0cac47a77042a3476a1c2f7058bfd6880
+  ReactCommon: c65f7049a542669dcc7bff6b7a8071a039c7d0dd
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 4ef80d96a5534f0e01b3055f17d1e19a9fc61b63
 
 PODFILE CHECKSUM: 9c8414c4cee2495dc87e0de22e0d57beb1caf2cb
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juspay/blaze-sdk-react-native",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "SDK for integrating Breeze 1CCO into your React Native Application",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
**Jira Ticket**
refer [ticket](https://juspay.atlassian.net/browse/BZ-42528)

**Why the changes?**
Version bump because of changes in android and sdk version

**Changes?**
- upgrade android sdk to 0.0.19-alpha & ios sdk to 0.4.0
- updated example to using terminate

**How to test?**
- run the new version of sdk on an ios and android app.
- navigate to all payment methods and webview redirects to ensure all are successfully happening.